### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/nevinxu/03399532-1c27-4ce1-99fe-d094c4f0e8db/566e6af7-d834-4003-9383-e1132bd8031f/_apis/work/boardbadge/c2fc5806-6d79-4043-8454-69a67b810aef)](https://dev.azure.com/nevinxu/03399532-1c27-4ce1-99fe-d094c4f0e8db/_boards/board/t/566e6af7-d834-4003-9383-e1132bd8031f/Microsoft.RequirementCategory)
 # hello-world
 first repository
 this is a test


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/nevinxu/03399532-1c27-4ce1-99fe-d094c4f0e8db/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.